### PR TITLE
Update install action

### DIFF
--- a/.github/actions/export/action.yml
+++ b/.github/actions/export/action.yml
@@ -19,8 +19,8 @@ inputs:
     description: 'The path to the snapshot files (i.e., the directory containing the snapshot.json file)'
     default: '.'
   descopecli_version:
-    description: 'The version of the descopecli tool to use'
-    default: 'v0.8.2'
+    description: 'The version of the descope CLI tool to use'
+    default: 'v0.8.6'
   descope_base_url:
     description: 'The base URL used to communicate with Descope servers (for troubleshooting purposes)'
 

--- a/.github/actions/export/action.yml
+++ b/.github/actions/export/action.yml
@@ -75,7 +75,7 @@ runs:
         echo "Exporting snapshot"
         rm -rf "${{ inputs.files_path }}"
         mkdir -p "${{ inputs.files_path }}"
-        descopecli project snapshot export "${{ inputs.project_id }}" --path "${{ inputs.files_path }}"
+        descope project snapshot export "${{ inputs.project_id }}" --path "${{ inputs.files_path }}"
 
     - name: Check For Changes
       id: check

--- a/.github/actions/import/action.yml
+++ b/.github/actions/import/action.yml
@@ -28,8 +28,8 @@ inputs:
     description: 'Whether to only perform the import step (for building workflows where import is a separate job)'
     type: boolean
   descopecli_version:
-    description: 'The version of the descopecli tool to use'
-    default: 'v0.8.2'
+    description: 'The version of the descope CLI tool to use'
+    default: 'v0.8.6'
   descope_base_url:
     description: 'The base URL used to communicate with Descope servers (for troubleshooting purposes)'
 

--- a/.github/actions/import/action.yml
+++ b/.github/actions/import/action.yml
@@ -86,7 +86,7 @@ runs:
         SECRETS_OUTPUT="$(mktemp)"
         FAILURES_OUTPUT="$(mktemp)"
         jq -r '.inputs.secrets' $GITHUB_EVENT_PATH > "$SECRETS_INPUT"
-        descopecli project snapshot validate "${{ inputs.project_id }}" --path "${{ inputs.files_path }}" --secrets-input "$SECRETS_INPUT" --secrets-output "$SECRETS_OUTPUT" --failures-output "$FAILURES_OUTPUT"
+        descope project snapshot validate "${{ inputs.project_id }}" --path "${{ inputs.files_path }}" --secrets-input "$SECRETS_INPUT" --secrets-output "$SECRETS_OUTPUT" --failures-output "$FAILURES_OUTPUT"
         result=$?
         rm "$SECRETS_INPUT"
         if [ "$result" = "2" ]; then
@@ -110,7 +110,7 @@ runs:
         set +e
         SECRETS_INPUT="$(mktemp)"
         jq -r '.inputs.secrets' $GITHUB_EVENT_PATH > "$SECRETS_INPUT"
-        descopecli project snapshot import "${{ inputs.project_id }}" --path "${{ inputs.files_path }}" --secrets-input "$SECRETS_INPUT"
+        descope project snapshot import "${{ inputs.project_id }}" --path "${{ inputs.files_path }}" --secrets-input "$SECRETS_INPUT"
         result=$?
         rm "$SECRETS_INPUT"
         exit $result

--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -6,8 +6,8 @@ author: 'Descope'
 
 inputs:
   version:
-    description: 'The version of the descopecli tool to use'
-    default: 'latest'
+    description: 'The version of the descope CLI tool to use'
+    default: 'v0.8.6'
 
 runs:
   using: 'composite'

--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -22,10 +22,14 @@ runs:
       id: cache-cli
       uses: actions/cache@v4
       with:
-        path: ~/go/bin
+        path: ~/go/bin/descopecli
         key: ${{ runner.os }}-descopecli-${{ inputs.version }}
 
     - name: Install Descopecli
       if: steps.cache-cli.outputs.cache-hit != 'true'
       shell: bash
       run: go install github.com/descope/descopecli@${{ inputs.version }}
+
+    - name: Copy Renamed
+      shell: bash
+      run: cp ~/go/bin/descopecli ~/go/bin/descope


### PR DESCRIPTION
## Description
- Update actions to use explicit descope CLI version
- The `install` action now uses `descope` as the binary name instead of `descopecli` (though both are kept for now to maintain compatibility)

## Must
- [X] Tests
- [X] Documentation (if applicable)
