### PR TITLE
Remove warning about conflicting projectId between args and environment

### DIFF
--- a/accesskey/crud.go
+++ b/accesskey/crud.go
@@ -14,7 +14,7 @@ func Create(args []string) error {
 		tenants = append(tenants, &descope.AssociatedTenant{TenantID: tenantID})
 	}
 
-	cleartext, res, err := shared.Descope.Management.AccessKey().Create(context.Background(), args[0], Flags.Expires, nil, tenants, Flags.UserId, nil)
+	cleartext, res, err := shared.Descope.Management.AccessKey().Create(context.Background(), args[0], Flags.Expires, nil, tenants, Flags.UserId, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/descope/descopecli
 go 1.21
 
 require (
-	github.com/descope/go-sdk v1.6.5
+	github.com/descope/go-sdk v1.6.6-0.20240718141635-7d1460916495
 	github.com/spf13/cobra v1.8.1
 	golang.org/x/exp v0.0.0-20240205201215-2c58cdc269a3
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 h1:8UrgZ3GkP4i/CLijOJx79Yu+etlyjdBU4sfcs2WYQMs=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
-github.com/descope/go-sdk v1.6.5 h1:49S5Yw81r+2bueCmIxMalEjtjJubSrCxU0QXiyUn32g=
-github.com/descope/go-sdk v1.6.5/go.mod h1:0gMVEB7wV2jlcNN3ZkhkKtGx4l1vJWpBF7Kq8Haq8sU=
+github.com/descope/go-sdk v1.6.6-0.20240718141635-7d1460916495 h1:Q9kyCMI1uMbw+3rwfhY87HQ5VhBcJSv+4MAR4mHg24c=
+github.com/descope/go-sdk v1.6.6-0.20240718141635-7d1460916495/go.mod h1:0gMVEB7wV2jlcNN3ZkhkKtGx4l1vJWpBF7Kq8Haq8sU=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/shared/client.go
+++ b/shared/client.go
@@ -42,9 +42,6 @@ func createDescopeClient(args []string, project bool) (*client.DescopeClient, er
 	}
 
 	if project {
-		if config.ProjectID != "" && args[0] != config.ProjectID {
-			return nil, errors.New("the " + descope.EnvironmentVariableProjectID + " environment variable must not conflict with the command argument")
-		}
 		config.ProjectID = args[0]
 		if !strings.HasPrefix(config.ProjectID, "P") {
 			return nil, errors.New("the command argument must be a valid projectId")


### PR DESCRIPTION
## Description
- Remove warning about conflicting projectId between args and environment

## Must
- [X] Tests
- [X] Documentation (if applicable)
