### PR TITLE
Bump version to v0.8.7

### DIFF
--- a/.github/actions/export/action.yml
+++ b/.github/actions/export/action.yml
@@ -20,7 +20,7 @@ inputs:
     default: '.'
   descopecli_version:
     description: 'The version of the descope CLI tool to use'
-    default: 'v0.8.6'
+    default: 'v0.8.7'
   descope_base_url:
     description: 'The base URL used to communicate with Descope servers (for troubleshooting purposes)'
 

--- a/.github/actions/import/action.yml
+++ b/.github/actions/import/action.yml
@@ -29,7 +29,7 @@ inputs:
     type: boolean
   descopecli_version:
     description: 'The version of the descope CLI tool to use'
-    default: 'v0.8.6'
+    default: 'v0.8.7'
   descope_base_url:
     description: 'The base URL used to communicate with Descope servers (for troubleshooting purposes)'
 

--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -7,7 +7,7 @@ author: 'Descope'
 inputs:
   version:
     description: 'The version of the descope CLI tool to use'
-    default: 'v0.8.6'
+    default: 'v0.8.7'
 
 runs:
   using: 'composite'

--- a/accesskey/cmd.go
+++ b/accesskey/cmd.go
@@ -6,20 +6,21 @@ import (
 )
 
 var Flags struct {
-	Name    string
-	Expires int64
-	UserId  string
-	Tenants []string
+	Description string
+	Expires     int64
+	UserId      string
+	Tenants     []string
 }
 
 func AddCommands(parent *cobra.Command, group *cobra.Group) {
 	accessKey := shared.MakeGroupCommand(group, "access-key", "Commands for creating and managing access keys")
 	parent.AddCommand(accessKey)
 
-	shared.AddCommand(accessKey, Create, "create <name> [-e time] [-t tenants] [-u userId]", "Create a new access key", func(cmd *cobra.Command) {
+	shared.AddCommand(accessKey, Create, "create <name> [-d description] [-e time] [-t tenants] [-u userId]", "Create a new access key", func(cmd *cobra.Command) {
 		cmd.Args = cobra.ExactArgs(1)
+		cmd.Flags().StringVarP(&Flags.Description, "description", "d", "", "an optional description for the access key")
 		cmd.Flags().Int64VarP(&Flags.Expires, "expires", "e", 0, "the access key's expiry time (unix time in seconds, default 0 to not expire)")
-		cmd.Flags().StringSliceVarP(&Flags.Tenants, "tenants", "t", nil, "a comma separated list of tenant ids for the user")
+		cmd.Flags().StringSliceVarP(&Flags.Tenants, "tenants", "t", nil, "a comma separated list of tenant ids for the access key")
 		cmd.Flags().StringVarP(&Flags.UserId, "userId", "u", "", "an optional user id to adopt authorizations from")
 	})
 

--- a/accesskey/crud.go
+++ b/accesskey/crud.go
@@ -14,7 +14,7 @@ func Create(args []string) error {
 		tenants = append(tenants, &descope.AssociatedTenant{TenantID: tenantID})
 	}
 
-	cleartext, res, err := shared.Descope.Management.AccessKey().Create(context.Background(), args[0], Flags.Expires, nil, tenants, Flags.UserId, nil, nil)
+	cleartext, res, err := shared.Descope.Management.AccessKey().Create(context.Background(), args[0], Flags.Description, Flags.Expires, nil, tenants, Flags.UserId, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/descope/descopecli
 go 1.21
 
 require (
-	github.com/descope/go-sdk v1.6.6-0.20240718141635-7d1460916495
+	github.com/descope/go-sdk v1.6.6-0.20240807171053-8a6c2c5fa043
 	github.com/spf13/cobra v1.8.1
 	golang.org/x/exp v0.0.0-20240205201215-2c58cdc269a3
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 h1:8UrgZ3GkP4i/CLijOJx79Yu+etlyjdBU4sfcs2WYQMs=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
-github.com/descope/go-sdk v1.6.6-0.20240718141635-7d1460916495 h1:Q9kyCMI1uMbw+3rwfhY87HQ5VhBcJSv+4MAR4mHg24c=
-github.com/descope/go-sdk v1.6.6-0.20240718141635-7d1460916495/go.mod h1:0gMVEB7wV2jlcNN3ZkhkKtGx4l1vJWpBF7Kq8Haq8sU=
+github.com/descope/go-sdk v1.6.6-0.20240807171053-8a6c2c5fa043 h1:jsX/ZWDfc+FwDenc+FVtrEUThUgwlUFnRqMMFMRw+fQ=
+github.com/descope/go-sdk v1.6.6-0.20240807171053-8a6c2c5fa043/go.mod h1:0gMVEB7wV2jlcNN3ZkhkKtGx4l1vJWpBF7Kq8Haq8sU=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=


### PR DESCRIPTION
## Description
- Add `-d` option to `descope access-key create` to add a description
- Bump version to v0.8.7

## Must
- [X] Tests
- [X] Documentation (if applicable)
