### PR TITLE
Generate otp, magic link, and enchanted link for test users

### DIFF
--- a/.github/actions/ci/lint/action.yml
+++ b/.github/actions/ci/lint/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: Run Linter
       uses: golangci/golangci-lint-action@v6
       with:
-        version: v1.55.2
+        version: v1.61.0
         skip-pkg-cache: true
         skip-build-cache: true
         args: --config=.github/actions/ci/lint/golangci.yml

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ lint: ensure-linter ensure-gitleaks ## check for linter and gitleaks failures
 
 ensure-linter: ensure-go
 	if ! command -v golangci-lint &> /dev/null; then \
-		go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.55.2 ;\
+		go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0 ;\
 	fi
 
 ensure-gitleaks:

--- a/accesskey/cmd.go
+++ b/accesskey/cmd.go
@@ -32,7 +32,7 @@ func AddCommands(parent *cobra.Command, group *cobra.Group) {
 		cmd.Args = cobra.ExactArgs(1)
 	})
 
-	shared.AddCommand(accessKey, LoadAll, "load-all", "Load all access keys", func(cmd *cobra.Command) {
+	shared.AddCommand(accessKey, LoadAll, "load-all", "Load all access keys", func(_ *cobra.Command) {
 	})
 
 	shared.AddCommand(accessKey, Activate, "activate <id>", "Activate an access key", func(cmd *cobra.Command) {

--- a/shared/syntax.go
+++ b/shared/syntax.go
@@ -12,7 +12,7 @@ func AddCommand(parent *cobra.Command, action func([]string) error, use string, 
 		Short:                 help,
 		DisableFlagsInUseLine: true,
 		PreRunE:               DefaultPreRun,
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, args []string) {
 			err := action(args)
 			ExitWithStatus(err)
 			if err != nil {

--- a/tenant/cmd.go
+++ b/tenant/cmd.go
@@ -29,6 +29,6 @@ func AddCommands(parent *cobra.Command, group *cobra.Group) {
 		cmd.Args = cobra.ExactArgs(1)
 	})
 
-	shared.AddCommand(tenant, LoadAll, "load-all", "Load all tenants", func(cmd *cobra.Command) {
+	shared.AddCommand(tenant, LoadAll, "load-all", "Load all tenants", func(_ *cobra.Command) {
 	})
 }

--- a/user/cmd.go
+++ b/user/cmd.go
@@ -100,7 +100,7 @@ func AddCommands(parent *cobra.Command, group *cobra.Group) {
 
 	shared.AddCommand(test, CreateTestUser, createUse, "Create a new test user", createSetup)
 
-	shared.AddCommand(test, DeleteAllTestUsers, "delete-all", "Delete all existing test users in the project", func(cmd *cobra.Command) {
+	shared.AddCommand(test, DeleteAllTestUsers, "delete-all", "Delete all existing test users in the project", func(_ *cobra.Command) {
 	})
 
 	generate := shared.MakeGroupCommand(nil, "generate", "Commands for generating logins for test users")

--- a/user/cmd.go
+++ b/user/cmd.go
@@ -102,4 +102,21 @@ func AddCommands(parent *cobra.Command, group *cobra.Group) {
 
 	shared.AddCommand(test, DeleteAllTestUsers, "delete-all", "Delete all existing test users in the project", func(cmd *cobra.Command) {
 	})
+
+	generate := shared.MakeGroupCommand(nil, "generate", "Commands for generating logins for test users")
+	test.AddCommand(generate)
+
+	shared.AddCommand(generate, GenerarteTestUserOTP, "otp <method> <loginId>", "Generate an OTP for a test user using email, sms, or voice", func(cmd *cobra.Command) {
+		cmd.Args = cobra.ExactArgs(2)
+	})
+
+	shared.AddCommand(generate, GenerarteTestUserMagicLink, "magic-link <method> <loginId> [-u url]", "Generate a magic link for a test user using email or sms", func(cmd *cobra.Command) {
+		cmd.Args = cobra.ExactArgs(2)
+		cmd.Flags().StringVarP(&Flags.RedirectURL, "redirect-url", "u", "", "override the redirect URL configured for enchanted link in the project configuration")
+	})
+
+	shared.AddCommand(generate, GenerarteTestUserEnchantedLink, "enchanted-link <loginId> [-u url]", "Generate an enchanted link and a pendingRef which is used to poll for a valid session", func(cmd *cobra.Command) {
+		cmd.Args = cobra.ExactArgs(1)
+		cmd.Flags().StringVarP(&Flags.RedirectURL, "redirect-url", "u", "", "override the redirect URL configured for enchanted link in the project configuration")
+	})
 }

--- a/user/test.go
+++ b/user/test.go
@@ -2,8 +2,11 @@ package user
 
 import (
 	"context"
+	"errors"
+	"net/url"
 
 	"github.com/descope/descopecli/shared"
+	"github.com/descope/go-sdk/descope"
 )
 
 type enchantedLink struct {
@@ -17,4 +20,46 @@ func CreateTestUser(args []string) error {
 
 func DeleteAllTestUsers(_ []string) error {
 	return shared.Descope.Management.User().DeleteAllTestUsers(context.Background())
+}
+
+func GenerarteTestUserOTP(args []string) error {
+	method := descope.DeliveryMethod(args[0])
+	if method != "email" && method != "sms" && method != "voice" {
+		return errors.New("method must be either email, sms, or voice")
+	}
+	code, err := shared.Descope.Management.User().GenerateOTPForTestUser(context.Background(), method, args[1], nil)
+	if err != nil {
+		return err
+	}
+	shared.ExitWithResult(code, "code", "Generated OTP for test user")
+	return nil
+}
+
+func GenerarteTestUserMagicLink(args []string) error {
+	method := descope.DeliveryMethod(args[0])
+	if method != "email" && method != "sms" {
+		return errors.New("method must be either email or sms")
+	}
+	link, err := shared.Descope.Management.User().GenerateMagicLinkForTestUser(context.Background(), method, args[1], Flags.RedirectURL, nil)
+	if err != nil {
+		return err
+	}
+	if _, err := url.ParseRequestURI(link); err != nil {
+		return errors.New("ensure a redirect URL is configured or specify one with the -u flag")
+	}
+	shared.ExitWithResult(link, "link", "Generated magic link for test user")
+	return nil
+}
+
+func GenerarteTestUserEnchantedLink(args []string) error {
+	link, pendingRef, err := shared.Descope.Management.User().GenerateEnchantedLinkForTestUser(context.Background(), args[0], Flags.RedirectURL, nil)
+	if err != nil {
+		return err
+	}
+	if _, err := url.ParseRequestURI(link); err != nil {
+		return errors.New("ensure a redirect URL is configured or specify one with the -u flag")
+	}
+	result := enchantedLink{Link: link, PendingRef: pendingRef}
+	shared.ExitWithResult(result, "result", "Generated enchanted link for test user")
+	return nil
 }


### PR DESCRIPTION
## Description
- Add `descope user test generate` commands to generate OTP, magic link, enchanted link

<img width="676" src="https://github.com/user-attachments/assets/42a7b413-51f5-4044-8aa6-cf4f87560970">

## Must
- [X] Tests
- [X] Documentation (if applicable)
