### PR TITLE
Add export and import for flows and themes

### DIFF
--- a/flow/cmd.go
+++ b/flow/cmd.go
@@ -1,0 +1,23 @@
+package flow
+
+import (
+	"github.com/descope/descopecli/shared"
+	"github.com/spf13/cobra"
+)
+
+func AddCommands(parent *cobra.Command, group *cobra.Group) {
+	flow := shared.MakeGroupCommand(group, "flow", "Commands for managing flows")
+	parent.AddCommand(flow)
+
+	shared.AddCommand(flow, List, "list", "Lists all flows in a project", func(cmd *cobra.Command) {
+		cmd.Args = cobra.NoArgs
+	})
+
+	shared.AddCommand(flow, Export, "export <flowId> [targetPath]", "Export a flow to a JSON file or standard output", func(cmd *cobra.Command) {
+		cmd.Args = cobra.RangeArgs(1, 2)
+	})
+
+	shared.AddCommand(flow, Import, "import <flowId> <sourcePath>", "Import a flow from a JSON file", func(cmd *cobra.Command) {
+		cmd.Args = cobra.ExactArgs(2)
+	})
+}

--- a/flow/crud.go
+++ b/flow/crud.go
@@ -1,0 +1,55 @@
+package flow
+
+import (
+	"context"
+
+	"github.com/descope/descopecli/shared"
+)
+
+func List(_ []string) error {
+	res, err := shared.Descope.Management.Flow().ListFlows(context.Background())
+	if err != nil {
+		return err
+	}
+
+	shared.ExitWithResults(res.Flows, "flows", "Flow", "Loaded", "flow", "flows")
+	return nil
+}
+
+func Export(args []string) error {
+	flow, err := shared.Descope.Management.Flow().ExportFlow(context.Background(), args[0])
+	if err != nil {
+		return err
+	}
+
+	shared.OmitEmpty(flow["metadata"])
+	if isEmpty := shared.OmitEmpty(flow["references"]); isEmpty {
+		delete(flow, "references")
+	}
+	if screens, ok := flow["screens"].([]any); ok {
+		for i := range screens {
+			if screen, ok := screens[i].(map[string]any); ok {
+				shared.OmitEmpty(screen["interactions"])
+			}
+		}
+	}
+
+	if len(args) == 2 {
+		return shared.WriteJSONFile(args[1], flow)
+	}
+
+	if shared.Flags.Json {
+		shared.ExitWithResult(flow, "flow", "Exported flow")
+	}
+
+	shared.PrintIndented(flow)
+	return nil
+}
+
+func Import(args []string) error {
+	flow, err := shared.ReadJSONFile[map[string]any](args[1])
+	if err != nil {
+		return err
+	}
+	return shared.Descope.Management.Flow().ImportFlow(context.Background(), args[0], flow)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/descope/descopecli
 go 1.21
 
 require (
-	github.com/descope/go-sdk v1.6.7
+	github.com/descope/go-sdk v1.6.8-0.20241114130308-1b642e806b07
 	github.com/spf13/cobra v1.8.1
 	golang.org/x/exp v0.0.0-20240205201215-2c58cdc269a3
 )

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 h1:8UrgZ3GkP4i/CLijOJx79Yu+etlyjdBU4sfcs2WYQMs=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
-github.com/descope/go-sdk v1.6.7 h1:GavKAlOaLU5rxvfM8n8uXdNBL+EpBh+dQPNUejIqY2o=
-github.com/descope/go-sdk v1.6.7/go.mod h1:0gMVEB7wV2jlcNN3ZkhkKtGx4l1vJWpBF7Kq8Haq8sU=
+github.com/descope/go-sdk v1.6.8-0.20241114130308-1b642e806b07 h1:Kra8S/O7yjv9RBF51IJzva7sjHwj8sczPnq0wpTyP2s=
+github.com/descope/go-sdk v1.6.8-0.20241114130308-1b642e806b07/go.mod h1:0gMVEB7wV2jlcNN3ZkhkKtGx4l1vJWpBF7Kq8Haq8sU=
 github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
 github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=

--- a/main.go
+++ b/main.go
@@ -5,8 +5,10 @@ import (
 
 	"github.com/descope/descopecli/accesskey"
 	"github.com/descope/descopecli/audit"
+	"github.com/descope/descopecli/flow"
 	"github.com/descope/descopecli/project"
 	"github.com/descope/descopecli/tenant"
+	"github.com/descope/descopecli/theme"
 	"github.com/descope/descopecli/user"
 	"github.com/spf13/cobra"
 )
@@ -33,6 +35,8 @@ func main() {
 
 	audit.AddCommands(cli, proj)
 	project.AddCommands(cli, proj)
+	flow.AddCommands(cli, proj)
+	theme.AddCommands(cli, proj)
 
 	if err := cli.Execute(); err != nil {
 		os.Exit(1)

--- a/shared/json.go
+++ b/shared/json.go
@@ -1,0 +1,55 @@
+package shared
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+func ReadJSONFile[T any](sourcePath string) (obj T, err error) {
+	bytes, err := os.ReadFile(sourcePath)
+	if err != nil {
+		return obj, fmt.Errorf("failed to read source file %s: %w", sourcePath, err)
+	}
+	if err = json.Unmarshal(bytes, &obj); err != nil {
+		return obj, fmt.Errorf("failed to parse source file %s: %w", sourcePath, err)
+	}
+	return obj, nil
+}
+
+func WriteJSONFile(path string, object map[string]any) error {
+	bytes, err := json.MarshalIndent(object, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to format JSON file %s: %w", path, err)
+	}
+	bytes = append(bytes, '\n')
+	if err = os.WriteFile(path, bytes, 0644); err != nil {
+		return fmt.Errorf("failed to write JSON file %s: %w", path, err)
+	}
+	return nil
+}
+
+func OmitEmpty(v any) (isEmpty bool) {
+	switch v := v.(type) {
+	case string:
+		return v == ""
+	case bool:
+		return !v
+	case float64:
+		return v == 0
+	case []any:
+		for i := range v {
+			OmitEmpty(v[i])
+		}
+		return len(v) == 0
+	case map[string]any:
+		for key, value := range v {
+			if isKeyEmpty := OmitEmpty(value); isKeyEmpty {
+				delete(v, key)
+			}
+		}
+		return len(v) == 0
+	default:
+		return v == nil
+	}
+}

--- a/theme/cmd.go
+++ b/theme/cmd.go
@@ -1,0 +1,23 @@
+package theme
+
+import (
+	"github.com/descope/descopecli/shared"
+	"github.com/spf13/cobra"
+)
+
+var Flags struct {
+	Skip bool
+}
+
+func AddCommands(parent *cobra.Command, group *cobra.Group) {
+	theme := shared.MakeGroupCommand(group, "theme", "Commands for managing themes")
+	parent.AddCommand(theme)
+
+	shared.AddCommand(theme, Export, "export [targetPath]", "Export the project theme to a JSON file or standard output", func(cmd *cobra.Command) {
+		cmd.Args = cobra.RangeArgs(0, 1)
+	})
+
+	shared.AddCommand(theme, Import, "import <sourcePath>", "Import the project theme from a JSON file", func(cmd *cobra.Command) {
+		cmd.Args = cobra.ExactArgs(1)
+	})
+}

--- a/theme/crud.go
+++ b/theme/crud.go
@@ -1,0 +1,37 @@
+package theme
+
+import (
+	"context"
+
+	"github.com/descope/descopecli/shared"
+)
+
+func Export(args []string) error {
+	theme, err := shared.Descope.Management.Flow().ExportTheme(context.Background())
+	if err != nil {
+		return err
+	}
+
+	if isEmpty := shared.OmitEmpty(theme["references"]); isEmpty {
+		delete(theme, "references")
+	}
+
+	if len(args) != 0 {
+		return shared.WriteJSONFile(args[0], theme)
+	}
+
+	if shared.Flags.Json {
+		shared.ExitWithResult(theme, "theme", "Exported theme")
+	}
+
+	shared.PrintIndented(theme)
+	return nil
+}
+
+func Import(args []string) error {
+	theme, err := shared.ReadJSONFile[map[string]any](args[0])
+	if err != nil {
+		return err
+	}
+	return shared.Descope.Management.Flow().ImportTheme(context.Background(), theme)
+}


### PR DESCRIPTION
## Description
- Add `flow` and `theme` command categories with `export` and `import` subcommands.
- Also add flow list command as `descope flow list`.

<img width="554" src="https://github.com/user-attachments/assets/d5d2a661-2a75-47bd-b6d7-68df4e30ea35">

## Must
- [X] Tests
- [X] Documentation (if applicable)
