### PR TITLE
feat: add support for using userID as the identifier in the management api

### DIFF
--- a/user/cmd.go
+++ b/user/cmd.go
@@ -10,6 +10,7 @@ var Flags struct {
 	UserID      string
 	TenantID    string
 	Email       string
+	Verified    bool
 	Phone       string
 	Name        string
 	Tenants     []string
@@ -93,6 +94,18 @@ func AddCommands(parent *cobra.Command, group *cobra.Group) {
 		cmd.Args = cobra.ExactArgs(1)
 		cmd.Flags().StringSliceVarP(&Flags.Roles, "roles", "r", nil, "a comma separated list of role names to remove")
 		cmd.Flags().StringVarP(&Flags.TenantID, "tenant", "t", "", "update the roles for the user in a specific tenant")
+	})
+
+	update := shared.MakeGroupCommand(nil, "update", "Commands for updating user details")
+	user.AddCommand(update)
+
+	shared.AddCommand(update, UpdateEmail, "email {-l loginId | -u userId} --email <email_address> [--verified]", "Sets the email for a user", func(cmd *cobra.Command) {
+		cmd.Flags().StringVarP(&Flags.LoginID, "login-id", "l", "", "the user's loginId")
+		cmd.Flags().StringVarP(&Flags.UserID, "user-id", "u", "", "the user's userId")
+		cmd.Flags().StringVarP(&Flags.Email, "email", "e", "", "the email to set for the user")
+		cmd.Flags().BoolVarP(&Flags.Verified, "verified", "v", false, "is the email address verified, deafult is false")
+		cmd.MarkFlagRequired("email")
+		cmd.MarkFlagsOneRequired("login-id", "user-id")
 	})
 
 	test := shared.MakeGroupCommand(nil, "test", "Commands for creating and managing test users")

--- a/user/crud.go
+++ b/user/crud.go
@@ -78,3 +78,23 @@ func LoadAll(_ []string) error {
 	shared.ExitWithResults(res, "users", "User", "Loaded", "user", "users")
 	return nil
 }
+
+func UpdateEmail(_ []string) error {
+	if (Flags.LoginID == "" && Flags.UserID == "") || (Flags.LoginID != "" && Flags.UserID != "") {
+		return errors.New("this command requires 1 flag to identify the user")
+	}
+
+	var user *descope.UserResponse
+	var err error
+	if Flags.LoginID != "" {
+		user, err = shared.Descope.Management.User().UpdateEmail(context.Background(), Flags.LoginID, Flags.Email, Flags.Verified)
+	} else {
+		user, err = shared.Descope.Management.User().UpdateEmailByUserId(context.Background(), Flags.UserID, Flags.Email, Flags.Verified)
+	}
+	if err != nil {
+		return err
+	}
+
+	shared.ExitWithResult(user, "user", "Updated user email")
+	return nil
+}

--- a/user/crud.go
+++ b/user/crud.go
@@ -89,7 +89,7 @@ func UpdateEmail(_ []string) error {
 	if Flags.LoginID != "" {
 		user, err = shared.Descope.Management.User().UpdateEmail(context.Background(), Flags.LoginID, Flags.Email, Flags.Verified)
 	} else {
-		user, err = shared.Descope.Management.User().UpdateEmailByUserId(context.Background(), Flags.UserID, Flags.Email, Flags.Verified)
+		user, err = shared.Descope.Management.User().UpdateEmailByUserID(context.Background(), Flags.UserID, Flags.Email, Flags.Verified)
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description
Assists in testing https://github.com/descope/etc/issues/2515

## Must
- [ ] Tests
- [ ] Documentation (if applicable)
